### PR TITLE
Make bootfiles in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: c
 matrix:
   include:
     # macOS
-    - env: TARGET_MACHINE=i3osx
-      os: osx
-    - env: TARGET_MACHINE=ti3osx
-      os: osx
-    - env: TARGET_MACHINE=a6osx
-      os: osx
-    - env: TARGET_MACHINE=ta6osx
-      os: osx
+    #- env: TARGET_MACHINE=i3osx
+    #  os: osx
+    #- env: TARGET_MACHINE=ti3osx
+    #  os: osx
+    #- env: TARGET_MACHINE=a6osx
+    #  os: osx
+    #- env: TARGET_MACHINE=ta6osx
+    #  os: osx
 
     # Linux
     - env: TARGET_MACHINE=i3le
@@ -21,6 +21,7 @@ matrix:
             - lib32ncurses5-dev
             - libx32ncurses5-dev
             - uuid-dev:i386
+            - libssl-dev:i386
     - env: TARGET_MACHINE=ti3le
       os: linux
       addons:
@@ -30,33 +31,36 @@ matrix:
             - lib32ncurses5-dev
             - libx32ncurses5-dev
             - uuid-dev:i386
+            - libssl-dev:i386
     - env: TARGET_MACHINE=a6le
       os: linux
     - env: TARGET_MACHINE=ta6le
       os: linux
 
     # Windows
-    - env: TARGET_MACHINE=i3nt
-      os: windows
-      before_script:
-        - git config core.autocrlf false; rm .git/index; git reset --hard
-        - choco install make -y
-    - env: TARGET_MACHINE=ti3nt
-      os: windows
-      before_script:
-        - git config core.autocrlf false; rm .git/index; git reset --hard
-        - choco install make -y
-    - env: TARGET_MACHINE=a6nt
-      os: windows
-      before_script:
-        - git config core.autocrlf false; rm .git/index; git reset --hard
-        - choco install make -y
-    - env: TARGET_MACHINE=ta6nt
-      os: windows
-      before_script:
-        - git config core.autocrlf false; rm .git/index; git reset --hard
-        - choco install make -y
+    #- env: TARGET_MACHINE=i3nt
+    #  os: windows
+    #  before_script:
+    #    - git config core.autocrlf false; rm .git/index; git reset --hard
+    #    - choco install make -y
+    #- env: TARGET_MACHINE=ti3nt
+    #  os: windows
+    #  before_script:
+    #    - git config core.autocrlf false; rm .git/index; git reset --hard
+    #    - choco install make -y
+    #- env: TARGET_MACHINE=a6nt
+    #  os: windows
+    #  before_script:
+    #    - git config core.autocrlf false; rm .git/index; git reset --hard
+    #    - choco install make -y
+    #- env: TARGET_MACHINE=ta6nt
+    #  os: windows
+    #  before_script:
+    #    - git config core.autocrlf false; rm .git/index; git reset --hard
+    #    - choco install make -y
 dist: xenial
+before_script:
+  - .travis/dobootfile.sh
 script:
   - .travis/build.sh
   - .travis/test.sh

--- a/.travis/dobootfile.sh
+++ b/.travis/dobootfile.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -v
+
+cd ..
+
+case $TARGET_MACHINE in
+  *i3le|ti3le) INST=i386;;
+  *a6le|ta6le) INST=x86_64;;
+  *)
+esac
+curl -L -o installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/min-racket-current-${INST}-linux-precise.sh
+sh installer.sh --in-place --dest ~/racket/
+
+~/racket/bin/racket -v
+~/racket/bin/raco pkg install -i --auto --no-setup cs-bootstrap
+~/racket/bin/raco setup -D cs-bootstrap
+
+cd ChezScheme/
+
+export MACH=$TARGET_MACHINE
+~/racket/bin/racket -l cs-bootstrap
+


### PR DESCRIPTION
Now I'm using the `cs-bootstrap` package.

I disable the builds in windows and osx. Only the linux builds remain.

For the 32bit version of Chez Scheme I'm using the 32bit version of Racket. It is not necessary, but I's a nice touch. For these versions, I had to add the `libssl-dev:i386` library to the build because otherwise `raco` can't connect to the server.