### PR TITLE
Make variables unsigned to avoid ub in calculation

### DIFF
--- a/c/foreign.c
+++ b/c/foreign.c
@@ -85,7 +85,7 @@ static ptr bvstring(const char *s) {
 
 /* multiplier weights each character, h = n factors in the length */
 static iptr symhash(s) const char *s; {
-  iptr n, h;
+  uptr n, h;
 
   h = n = strlen(s);
   while (n--) h = h * multiplier + *s++;


### PR DESCRIPTION
According to ubsan we get several times into undefined behaviour due to signed overflow:
foreign.c:91:21: runtime error: signed integer overflow: 3291370622602663862 * 3 cannot be represented in type 'long int'

This happens only when the symbol name is relatively large like as for the call:
symhash (s=0x5555558caab8 "(cs)set_enable_object_backreferences")