### PR TITLE
Alternative version of enable-type-recovery

### DIFF
--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -27,31 +27,17 @@
         (expand/optimize y)))]))
 
 (define-syntax cptypes/nocp0-equivalent-expansion?
+  ; When run-cp0 is call, use #3%$cptypes insted of the cp0 function provided.
+  ; This disables the reductions in cp0.ss, so it's posible to see
+  ; the isolated effect of the reduction in cptypes.ss. 
   (syntax-rules ()
     [(_ x y)
      (equivalent-expansion?
-      (parameterize ([enable-cp0 #f]
+      (parameterize ([run-cp0 (lambda (cp0 c) (#3%$cptypes c))]
                      [#%$suppress-primitive-inlining #f]
                      #;[optimize-level (max (optimize-level) 2)])
         (expand/optimize x))
-      (parameterize ([enable-cp0 #f]
-                     [#%$suppress-primitive-inlining #f]
-                     #;[optimize-level (max (optimize-level) 2)])
-        (expand/optimize y)))]))
-
-(define-syntax cptypes/nocp0/alternative-equivalent-expansion?
-  (syntax-rules ()
-    [(_ x y)
-     (equivalent-expansion?
-      (parameterize ([enable-cp0 #f]
-                     [enable-type-recovery #f]
-                     [run-cp0 (lambda (cp0 c) (#3%$cptypes c))]
-                     [#%$suppress-primitive-inlining #f]
-                     #;[optimize-level (max (optimize-level) 2)])
-        (expand/optimize x))
-      (parameterize ([enable-cp0 #f]
-                     [enable-type-recovery #f]
-                     [run-cp0 (lambda (cp0 c) (#3%$cptypes c))]
+      (parameterize ([run-cp0 (lambda (cp0 c) (#3%$cptypes c))]
                      [#%$suppress-primitive-inlining #f]
                      #;[optimize-level (max (optimize-level) 2)])
         (expand/optimize y)))]))
@@ -677,21 +663,6 @@
     '((lambda (x . r) (pair? r)) 1 2)
     '((lambda (x . r) #t) 1 2))
   (cptypes/nocp0-equivalent-expansion?
-    '((lambda (x . r) (null? r)) 1 2)
-    '((lambda (x . r) #f) 1 2))
-)
-
-(mat cptypes-rest-argument/alternative
-  (cptypes/nocp0/alternative-equivalent-expansion?
-    '((lambda (x . r) (pair? r)) 1)
-    '((lambda (x . r) #f) 1))
-  (cptypes/nocp0/alternative-equivalent-expansion?
-    '((lambda (x . r) (null? r)) 1)
-    '((lambda (x . r) #t) 1))
-  (cptypes/nocp0/alternative-equivalent-expansion?
-    '((lambda (x . r) (pair? r)) 1 2)
-    '((lambda (x . r) #t) 1 2))
-  (cptypes/nocp0/alternative-equivalent-expansion?
     '((lambda (x . r) (null? r)) 1 2)
     '((lambda (x . r) #f) 1 2))
 )

--- a/s/compile.ss
+++ b/s/compile.ss
@@ -667,9 +667,7 @@
                                   x2)])
                           (if cpletrec-ran?
                               x
-                              (let* ([x (cptypes x)]
-                                     [waste (check-prelex-flags x 'cptypes)]
-                                     [x ($pass-time 'cpletrec (lambda () (do-trace $cpletrec x)))]
+                              (let* ([x ($pass-time 'cpletrec (lambda () (do-trace $cpletrec x)))]
                                      [waste (check-prelex-flags x 'cpletrec)])
                                 x))))]
                  [x2b ($pass-time 'cpcheck (lambda () (do-trace $cpcheck x2a)))]
@@ -1578,8 +1576,7 @@
                                       ($pass-time 'cpletrec (lambda () ($cpletrec x)))))
                                   x2)])
                           (if cpletrec-ran? x
-                              (let ([x (cptypes x)])
-                                ($pass-time 'cpletrec (lambda () ($cpletrec x)))))))]
+                              ($pass-time 'cpletrec (lambda () ($cpletrec x))))))]
                  [x2b ($pass-time 'cpcheck (lambda () ($cpcheck x2a)))]
                  [x2b ($pass-time 'cpcommonize (lambda () ($cpcommonize x2b)))])
             (when (and (expand/optimize-output) (not ($noexpand? x0)))

--- a/s/cprep.ss
+++ b/s/cprep.ss
@@ -237,7 +237,7 @@
                               (set! cpletrec-ran? #t)
                               ($cpletrec (cptypes ($cp0 x $compiler-is-loaded?))))
                             ($cpvalid x))])
-                    (if cpletrec-ran? x ($cpletrec (cptypes x)))))))))
+                    (if cpletrec-ran? x ($cpletrec x))))))))
         (unless (environment? env)
           ($oops who "~s is not an environment" env))
         ; claim compiling-a-file to get cte as well as run-time code


### PR DESCRIPTION
Don't run cptypes, when cp0 is disabled, for example with

    (run-cp0 (lamba (cp0 x) x)

This is easier to understand because `run-cp0` is a single point to control for all the cp reductions. The reductions in cptypes can be independently disabled using `enable-type-recovery`.

Currently, if cp0 is not run, then the compiler calls cptypes once anyway. (Note that the interpreted version didn't have this additional call.) 