### PR TITLE
Cptypes: add support for call-with-values and use define-inline

### DIFF
--- a/mats/cp0.ms
+++ b/mats/cp0.ms
@@ -2255,10 +2255,10 @@
   (equivalent-expansion?
     (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f])
       ;; don't fold primitive in test context with bad apply convention
-      (expand/optimize '(if (#%apply #%eof-object 1 2 3) 4 5)))
+      (expand/optimize '(if (#%apply #%pair? 1 2 3) 4 5)))
     (if (= (optimize-level) 3)
-        '(if (#3%apply #3%eof-object 1 2 3) 4 5)
-        '(if (#2%apply #2%eof-object 1 2 3) 4 5)))
+        '(if (#3%apply #3%pair? 1 2 3) 4 5)
+        '(if (#2%apply #2%pair? 1 2 3) 4 5)))
   (equivalent-expansion?
     (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f])
       ;; don't fold primitive in effect context with bad apply convention

--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -670,6 +670,12 @@
   (not (cptypes-equivalent-expansion?
          '(lambda (x) (when (number? x) (#2%odd? x)))
          '(lambda (x) (when (number? x) (#3%odd? x)))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (number? x) (#2%exact? x)))
+    '(lambda (x) (when (number? x) (#3%exact? x))))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x) (#2%exact? x))
+         '(lambda (x) (#3%exact? x))))
 )
 
 (mat cptypes-rest-argument
@@ -685,4 +691,16 @@
   (cptypes/nocp0-equivalent-expansion?
     '((lambda (x . r) (null? r)) 1 2)
     '((lambda (x . r) #f) 1 2))
+)
+
+(mat cptypes-delay
+  (cptypes-equivalent-expansion?
+    '(lambda (b) (map (lambda (x) (box? b)) (unbox b)))
+    '(lambda (b) (map (lambda (x) #t) (unbox b))))
+  (cptypes-equivalent-expansion?
+    '(lambda (b) (list (lambda (x) (box? b)) (unbox b)))
+    '(lambda (b) (list (lambda (x) #t) (unbox b))))
+  (cptypes-equivalent-expansion?
+    '(lambda (b) (list (unbox b) (lambda (x) (box? b))))
+    '(lambda (b) (list (unbox b) (lambda (x) #t))))
 )

--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -704,3 +704,358 @@
     '(lambda (b) (list (unbox b) (lambda (x) (box? b))))
     '(lambda (b) (list (unbox b) (lambda (x) #t))))
 )
+
+(mat cptypes-call-with-values
+  ; The single value case is handled by cp0
+  (cptypes-equivalent-expansion?
+    '(lambda (v)
+       (call-with-values
+        (lambda () (vector-ref v 0))
+        (lambda (y) (list (vector? v) (vector-ref v 1) y))))
+    '(lambda (v)
+       (call-with-values
+        (lambda () (vector-ref v 0))
+        (lambda (y) (list #t (vector-ref v 1) y)))))
+  (cptypes-equivalent-expansion?
+    '(lambda (t)
+       (call-with-values
+        (lambda () (if t (box 2) (box 3)))
+        (lambda (y) (list y (box? y)))))
+    '(lambda (t)
+       (call-with-values
+        (lambda () (if t (box 2) (box 3)))
+        (lambda (y) (list y #t)))))
+  (cptypes-equivalent-expansion?
+    '(lambda (t b)
+       (call-with-values
+        (lambda () (if t 1 2))
+        (lambda (y) (display (unbox b))))
+       (box? b))
+    '(lambda (t b)
+       (call-with-values
+        (lambda () (if t 1 2))
+        (lambda (y) (display (unbox b))))
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (call-with-values
+        (lambda () (if (unbox b) 1 2))
+        (lambda (y) (display y)))
+       (box? b))
+    '(lambda (b)
+       (call-with-values
+        (lambda () (if (unbox b) 1 2))
+        (lambda (y) (display y)))
+       #t))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (call-with-values
+        (lambda () (if (unbox b) 1 (values 2 3)))
+        (lambda (x y) (list x y (box? b)))))
+    '(lambda (b)
+       (call-with-values
+        (lambda () (if (unbox b) 1 (values 2 3)))
+        (lambda (x y) (list x y #t)))))
+  (cptypes-equivalent-expansion?
+    '(lambda (t b)
+       (call-with-values
+        (lambda () (if t 1 (values 2 3)))
+        (lambda (x y) (display (list x y (unbox b)))))
+       (box? b))
+    '(lambda (t b)
+       (call-with-values
+        (lambda () (if t 1 (values 2 3)))
+        (lambda (x y) (display (list x y (unbox b)))))
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (call-with-values
+        (lambda () (if (unbox b) 1 (values 2 3)))
+        (lambda (x y) (display (list x y))))
+       (box? b))
+    '(lambda (b)
+       (call-with-values
+        (lambda () (if (unbox b) 1 (values 2 3)))
+        (lambda (x y) (display (list x y))))
+       #t))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (call-with-values
+        (case-lambda 
+          [() (if (unbox b) 1 (values 2 3))]
+          [(x) (error 'e "")])
+        (lambda (x y) (list x y (box? b)))))
+    '(lambda (b)
+       (call-with-values
+        (case-lambda 
+          [() (if (unbox b) 1 (values 2 3))]
+          [(x) (error 'e "")])
+        (lambda (x y) (list x y #t)))))
+  (cptypes-equivalent-expansion?
+    '(lambda (t b)
+       (call-with-values
+        (lambda () (if t 1 (values 2 3)))
+        (case-lambda
+         [(x y) (display (list x y (unbox b)))]
+         [(x) (error 'e "")]))
+       (box? b))
+    '(lambda (t b)
+       (call-with-values
+        (lambda () (if t 1 (values 2 3)))
+        (case-lambda
+         [(x y) (display (list x y (unbox b)))]
+         [(x) (error 'e "")]))
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (call-with-values
+        (case-lambda 
+          [() (if (unbox b) 1 (values 2 3))]
+          [(x) (error 'e "")])
+        (lambda (x y) (display (list x y))))
+       (box? b))
+    '(lambda (b)
+       (call-with-values
+        (case-lambda 
+          [() (if (unbox b) 1 (values 2 3))]
+          [(x) (error 'e "")])
+        (lambda (x y) (display (list x y))))
+       #t))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (t b)
+       (call-with-values
+        (begin (display (unbox b)) (lambda () (if t 1 (values b 2))))
+        (lambda (x y) (list x y (box? b)))))
+    '(lambda (t b)
+       (call-with-values
+        (begin (display (unbox b)) (lambda () (if t 1 (values b 2))))
+        (lambda (x y) (list x y #t)))))
+  ; This is difficult to handle in cptypes, so I ignored it.
+  ; But it is anyway handled by cp0.
+  #;(cptypes-equivalent-expansion?
+      '(lambda (t b)
+         (call-with-values
+          (lambda () (if t 1 (values b (box? b))))
+          (begin (display (unbox b)) (lambda (x y) (list x y b)))))
+      '(lambda (t b)
+         (call-with-values
+          (lambda () (if t 1 (values b #t)))
+          (begin (display (unbox b)) (lambda (x y) (list x y b))))))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (t)
+       (number?
+        (call-with-values
+         (lambda () (if t 1 (values 2 3)))
+         (case-lambda [(x y) 2] [(x) 1]))))
+    '(lambda (t)
+       (call-with-values
+        (lambda () (if t 1 (values 2 3)))
+        (case-lambda [(x y) 2] [(x) 1]))
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (t)
+       (number?
+        (call-with-values
+         (lambda () (if t 1 (values 2 3)))
+         (case-lambda [(x y) 2] [(x) (error 'e "")]))))
+    '(lambda (t)
+       (call-with-values
+        (lambda () (if t 1 (values 2 3)))
+        (case-lambda [(x y) 2] [(x) (error 'e "")]))
+       #t))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (t f)
+       (call-with-values
+        (lambda () (if t 1 (values 2 3)))
+         f)
+       (procedure? f))
+    '(lambda (t f)
+       (call-with-values
+        (lambda () (if t 1 (values 2 3)))
+         f)
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (t f)
+       (call-with-values
+        f
+        (lambda (x y) (+ x y)))
+       (procedure? f))
+    '(lambda (t f)
+       (call-with-values
+        f
+        (lambda (x y) (+ x y)))
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (t f)
+       (when (box? f)
+         (call-with-values
+          (lambda () (if t 1 (values 2 3)))
+          f)
+         111))
+    '(lambda (t f)
+       (when (box? f)
+         (call-with-values
+          (lambda () (if t 1 (values 2 3)))
+          f)
+         222)))
+  (cptypes-equivalent-expansion?
+    '(lambda (t f)
+       (when (box? f)
+         (call-with-values
+          f
+          (lambda (x y) (+ x y)))
+         111))
+    '(lambda (t f)
+       (when (box? f)
+         (call-with-values
+          f
+          (lambda (x y) (+ x y)))
+         222)))
+)
+
+(mat cptypes-apply
+  (cptypes-equivalent-expansion?
+    '(lambda (l b)
+       (apply (lambda (x) (display (list (unbox b) x))) l)
+       (box? b))
+    '(lambda (l b)
+       (apply (lambda (x) (display (list (unbox b) x))) l)
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (l b)
+       (apply (lambda (x y) (display (list (unbox b) x))) 7 l)
+       (box? b))
+    '(lambda (l b)
+       (apply (lambda (x y) (display (list (unbox b) x))) 7 l)
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (l b)
+       (apply (lambda (x) (display (list b x))) (unbox b))
+       (box? b))
+    '(lambda (l b)
+       (apply (lambda (x) (display (list b x))) (unbox b))
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (l b)
+       (apply (lambda (x y) (display (list b x y))) 7 (unbox b))
+       (box? b))
+    '(lambda (l b)
+       (apply (lambda (x y) (display (list b x y))) 7 (unbox b))
+       #t))
+
+  (cptypes-equivalent-expansion?
+    ; with #3% the argument may be inlined and then executed in reverse order
+    '(lambda (l b)
+       (#2%apply (lambda (x y) (list (box? b) x y)) 7 (unbox b)))
+    '(lambda (l b)
+       (#2%apply (lambda (x y) (list #t x y)) 7 (unbox b))))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (l b)
+       (apply
+        (case-lambda 
+          [(x) (list (unbox b) x)]
+          [(x y) (error 'e "")])
+        l)
+       (box? b)) 
+    '(lambda (l b)
+       (apply
+        (case-lambda 
+          [(x) (list (unbox b) x)]
+          [(x y) (error 'e "")])
+        l)
+       #t)) 
+
+  (cptypes-equivalent-expansion?
+    '(lambda (l)
+       (number?
+        (apply (lambda (x y) (+ x y)) l)))
+    '(lambda (l)
+       (apply (lambda (x y) (+ x y)) l)
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (l)
+       (number?
+        (apply
+         (case-lambda
+          [(x y) (+ x y)]
+          [()  (error 'e "")])
+         l)))
+    '(lambda (l)
+       (apply
+        (case-lambda
+         [(x y) (+ x y)]
+         [()  (error 'e "")])
+        l)
+       #t))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (f l)
+       (apply f l)
+       (procedure? f))
+    '(lambda (f l)
+       (apply f l)
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (t f)
+       (when (box? f)
+         (apply f l)
+         111))
+    '(lambda (t f)
+       (when (box? f)
+         (apply f l)
+         222)))
+)
+
+(mat cptypes-dynamic-wind
+  (cptypes-equivalent-expansion?
+    '(lambda (f)
+       (box? (dynamic-wind (lambda (x) #f) (lambda () (box (f))) (lambda () #f))))
+    '(lambda (f)
+       (begin
+         (dynamic-wind (lambda (x) #f) (lambda () (box (f))) (lambda () #f))
+         #t)))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (dynamic-wind (lambda (x) (unbox b)) (lambda () #f) (lambda () #f))
+       (box? b))
+    '(lambda (b)
+       (dynamic-wind (lambda (x) (unbox b)) (lambda () #f) (lambda () #f))
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (dynamic-wind (lambda (x) #f) (lambda () (unbox b)) (lambda () #f))
+       (box? b))
+    '(lambda (b)
+       (dynamic-wind (lambda (x) #f) (lambda () (unbox b)) (lambda () #f))
+       #t))
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (dynamic-wind (lambda (x) #f) (lambda () #f) (lambda () (unbox b)))
+       (box? b))
+    '(lambda (b)
+       (dynamic-wind (lambda (x) #f) (lambda () #f) (lambda () (unbox b)))
+       #t))
+
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (dynamic-wind (lambda (x) (unbox b)) (lambda () (box? b)) (lambda () #f)))
+    '(lambda (b)
+       (dynamic-wind (lambda (x) (unbox b)) (lambda () #t) (lambda () #f))))
+  (cptypes-equivalent-expansion?
+    '(lambda (b)
+       (dynamic-wind (lambda (x) (unbox b)) (lambda () #f) (lambda () (box? b))))
+    '(lambda (b)
+       (dynamic-wind (lambda (x) (unbox b)) (lambda () #f) (lambda () #t) )))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (b)
+            (dynamic-wind (lambda () #f) (lambda (x) (unbox b)) (lambda () (box? b))))
+         '(lambda (b)
+            (dynamic-wind (lambda () #f) (lambda (x) (unbox b)) (lambda () #t)))))
+)

--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -334,6 +334,26 @@
           '(lambda (x y z f)
             (let ([t (vector? x)])
               (if (if y #f z) (f t 1) (f t 2))))))
+  (cptypes-equivalent-expansion?
+     '(lambda (t b)
+       (if (if t (newline) (unbox b)) (vector? b) (box? b)))
+     '(lambda (t b)
+       (if (if t (newline) (unbox b)) (vector? b) #t)))
+  (cptypes-equivalent-expansion?
+     '(lambda (t b)
+       (if (if t (unbox b) (newline)) (vector? b) (box? b)))
+     '(lambda (t b)
+       (if (if t (unbox b) (newline)) (vector? b) #t)))
+  (cptypes-equivalent-expansion?
+     '(lambda (t b)
+       (if (if t #f (unbox b)) (vector? b) (box? b)))
+     '(lambda (t b)
+       (if (if t #f (unbox b)) #f (box? b))))
+  (cptypes-equivalent-expansion?
+     '(lambda (t b)
+       (if (if t (unbox b) #f) (vector? b) (box? b)))
+     '(lambda (t b)
+       (if (if t (unbox b) #f) #f (box? b))))
 )
 
 (mat cptype-directly-applied-case-lambda

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -1669,6 +1669,8 @@
   (unsafe                   #b00001000000000000000000)
   (unrestricted             #b00010000000000000000000)
   (safeongoodargs           #b00100000000000000000000)
+  (cptypes2                 #b01000000000000000000000)
+  (cptypes3                 cptypes2)
   (arith-op                 (or proc pure true))
   (alloc                    (or proc discard true))
   ; would be nice to check that these and only these actually have cp0 partial folders

--- a/s/cmacros.ss
+++ b/s/cmacros.ss
@@ -1671,6 +1671,8 @@
   (safeongoodargs           #b00100000000000000000000)
   (cptypes2                 #b01000000000000000000000)
   (cptypes3                 cptypes2)
+  (cptypes2x                cptypes2)
+  (cptypes3x                cptypes2)
   (arith-op                 (or proc pure true))
   (alloc                    (or proc discard true))
   ; would be nice to check that these and only these actually have cp0 partial folders

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -180,8 +180,8 @@
 )
 
 (define-symbol-flags* ([libraries (rnrs) (rnrs base)] [flags primitive proc])
-  (eqv? [sig [(ptr ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard cp02 ieee r5rs])
-  (eq? [sig [(ptr ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard cp02 ieee r5rs])
+  (eqv? [sig [(ptr ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard cp02 cptypes2 ieee r5rs])
+  (eq? [sig [(ptr ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard cp02 cptypes2 ieee r5rs])
   (equal? [sig [(ptr ptr) -> (boolean)]] [flags unrestricted mifoldable discard cp02 ieee r5rs])
   (procedure? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard ieee r5rs cp02])
   (number? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard ieee r5rs])
@@ -192,8 +192,8 @@
   (real-valued? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard])
   (rational-valued? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard])
   (integer-valued? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard])
-  (exact? [sig [(number) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])
-  (inexact? [sig [(number) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])
+  (exact? [sig [(number) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2 ieee r5rs])
+  (inexact? [sig [(number) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2 ieee r5rs])
   (inexact [sig [(number) -> (inexact-number)]] [flags arith-op mifoldable discard safeongoodargs])
   (exact [sig [(number) -> (exact-number)]] [flags arith-op mifoldable discard]) ; no safeongoodargs because it fails with +inf.0
   ((r6rs: <) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])   ; restricted to 2+ arguments
@@ -288,7 +288,7 @@
   (cddddr [sig [(#15#) -> (ptr)]] [flags mifoldable discard ieee r5rs])
   (null? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard ieee r5rs])
   (list? [sig [(ptr) -> (boolean)]] [flags unrestricted mifoldable discard ieee r5rs])
-  (list [sig [(ptr ...) -> (list)]] [flags unrestricted alloc cp02 ieee r5rs])
+  (list [sig [(ptr ...) -> (list)]] [flags unrestricted alloc cp02 cptypes2 ieee r5rs])
   (length [sig [(list) -> (length)]] [flags mifoldable discard true ieee r5rs])
   (append [sig [() -> (null)] [(list ... ptr) -> (ptr)]] [flags discard ieee r5rs cp02])
   (reverse [sig [(list) -> (list)]] [flags alloc ieee r5rs])
@@ -1580,7 +1580,7 @@
   (ratnum? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard])
   (read-token [sig [() (textual-input-port) (textual-input-port sfd) -> (symbol ptr maybe-uint maybe-uint)]] [flags])
   (real-time [sig [() -> (uint)]] [flags unrestricted alloc])
-  (record? [sig [(ptr) (ptr rtd) -> (boolean)]] [flags pure mifoldable discard cp02])
+  (record? [sig [(ptr) (ptr rtd) -> (boolean)]] [flags pure mifoldable discard cp02 cptypes2])
   (record-constructor [sig [(sub-ptr) -> (procedure)]] [flags cp02]) ; accepts rtd or rcd
   (record-constructor-descriptor? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable discard cp02])
   (record-equal-procedure [sig [(record record) -> (maybe-procedure)]] [flags discard])
@@ -1785,7 +1785,7 @@
   ($allocate-thread-parameter [feature pthreads] [flags single-valued alloc])
   ($app [flags])
   ($app/no-inline [flags])
-  ($apply [flags])
+  ($apply [sig [(procedure exact-integer list) -> (ptr ...)]] [flags])
   ($assembly-output [flags single-valued])
   ($as-time-goes-by [flags])
   ($bignum-length [flags single-valued pure true])
@@ -2229,7 +2229,7 @@
   ($real-sym-name [flags single-valued])
   ($recompile-condition? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable])
   ($recompile-importer-path [flags single-valued])
-  ($record [flags single-valued cp02 unrestricted alloc]) ; first arg should be an rtd, but we don't check
+  ($record [flags single-valued cp02 cptypes2 unrestricted alloc]) ; first arg should be an rtd, but we don't check
   ($record? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable])
   ($record-cas! [sig [(record sub-index ptr ptr) -> (boolean)]] [flags single-valued])
   ($record-equal-procedure [flags single-valued discard])
@@ -2255,7 +2255,7 @@
   ($sc-put-cte [flags single-valued])
   ($sc-put-property! [flags single-valued])
   ($script [flags single-valued])
-  ($sealed-record? [sig [(ptr rtd) -> (boolean)]] [flags pure mifoldable]) ; first argument may be not a record
+  ($sealed-record? [sig [(ptr rtd) -> (boolean)]] [flags pure mifoldable cptypes2]) ; first argument may be not a record
   ($seginfo-generation [flags single-valued])
   ($seginfo-space [flags single-valued])
   ($set-code-byte! [flags single-valued])

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -337,12 +337,12 @@
   (vector-for-each [sig [(procedure vector vector ...) -> (ptr ...)]] [flags cp03])
   (error [sig [(maybe-who string ptr ...) -> (bottom)]] [flags abort-op])
   (assertion-violation [sig [(maybe-who string ptr ...) -> (bottom)]] [flags abort-op])
-  (apply [sig [(procedure ptr ... list) -> (ptr ...)]] [flags cp02 ieee r5rs])
+  (apply [sig [(procedure ptr ... list) -> (ptr ...)]] [flags cp02 cptypes2x ieee r5rs])
   (call-with-current-continuation [sig [(procedure) -> (ptr ...)]] [flags ieee r5rs])
   (call/cc [sig [(procedure) -> (ptr ...)]] [flags])
   (values [sig [(ptr ...) -> (ptr ...)]] [flags unrestricted discard cp02 ieee r5rs])
-  (call-with-values [sig [(procedure procedure) -> (ptr ...)]] [flags cp02 ieee r5rs])
-  ((r6rs: dynamic-wind) [sig [(procedure procedure procedure) -> (ptr ...)]] [flags ieee r5rs])      ; restricted to 3 arguments
+  (call-with-values [sig [(procedure procedure) -> (ptr ...)]] [flags cp02 cptypes2x ieee r5rs])
+  ((r6rs: dynamic-wind) [sig [(procedure procedure procedure) -> (ptr ...)]] [flags cptypes2x ieee r5rs])      ; restricted to 3 arguments
 )
 
 (define-symbol-flags* ([libraries (rnrs) (rnrs bytevectors)] [flags keyword])
@@ -1270,7 +1270,7 @@
   (display-condition [sig [(ptr) (ptr textual-output-port) -> (void)]] [flags])
   (display-statistics [sig [() (textual-output-port) -> (void)]] [flags true])
   (display-string [sig [(string) (string textual-output-port) -> (void)]] [flags true])
-  (dynamic-wind [sig [(procedure procedure procedure) (ptr procedure procedure procedure) -> (ptr ...)]] [flags ieee r5rs])
+  (dynamic-wind [sig [(procedure procedure procedure) (ptr procedure procedure procedure) -> (ptr ...)]] [flags cptypes2x ieee r5rs])
   (enable-interrupts [sig [() -> (uint)]] [flags true])
   (engine-block [sig [() -> (ptr)]] [flags])
   (engine-return [sig [(ptr ...) -> (bottom)]] [flags abort-op])
@@ -1785,7 +1785,7 @@
   ($allocate-thread-parameter [feature pthreads] [flags single-valued alloc])
   ($app [flags])
   ($app/no-inline [flags])
-  ($apply [sig [(procedure exact-integer list) -> (ptr ...)]] [flags])
+  ($apply [sig [(procedure exact-integer list) -> (ptr ...)]] [flags cptypes2x])
   ($assembly-output [flags single-valued])
   ($as-time-goes-by [flags])
   ($bignum-length [flags single-valued pure true])


### PR DESCRIPTION
This is a big update. It's still work in progress but I'd like some feedback. (Definitively not ready for Racket 7.6, but hopefully ready for 7.7.)

It has a lot of small commits, my plan is to squash them in 4 of 5 before merging.

It has a lot of internal refactor. Main new features:

* Add support for `call-with-values`:

In some primitives, it is sure that the functions in the arguments will be called, and it's result is the result of the primitive.

    (begin (call-with-values (lambda () (unbox b)) something) (box? b))
    ;==>
    (begin (call-with-values (lambda () (unbox b)) something) #t)

 * Use `define-inline` like the other passes:

This makes the code more modular. Instead of a single big `cond`, each primitive has it's own block. The arguments are not wrapped in a `oprnd` like in the other passes. I'm using some macro magic instead, perhaps too much.

There is a version of `define-inline` for normal cases like `$sealed-record?` and another version for special cases that have need more control like `call-with-values`. The current name is `define-inline/weird` but I'd like a better name. :)

I'm reusing the same bit in the flags for all cases, because 4 bits is too much. Perhaps the flag can be skipped completely using a macro that reads `primdata.ss` directly.

* Delayed analysis for lambdas:

If a `lambda` is part of a list of an argument, it is analyzed after the other argument. So functions like `map` don't need an special case 

    (map (lambda (x) (box? b)) (unbox b))
    ;==>
    (map (lambda (x) #t) (unbox b))

* New special type `pred-env-bottom` that is "full" of `'bottom`s

This simplifies some parts of the code. The problem is that the information that a expression raises an error now is returned twice, most of the time in both. I'm not sure I'm 100% consistent, but this can't cause a problem, only some missed reductions. 

---

To do in a future version (in a few months, July?):

* Add a `app` context like in cp0:

The idea is to call the first argument of `(call f other-args ...)` using a context that is `app` that is a record that has all the information about the arguments and types. In the current version, I'm using a special case that is call `Expr/call` to handle the reduction of the functions that will be called surely. Also, it would be good that the return type of these expressions is special record `procedure/more-info` instead of a plain `'procedure`.

* Information for predicates in the signature:

Perhaps the signature in `primdata.ss` can say that the primitive is a predicate. Now the code uses a giant `case` to detect them.
