### PR TITLE
Fix record? reduction in cptypes

### DIFF
--- a/s/cptypes.ss
+++ b/s/cptypes.ss
@@ -863,8 +863,11 @@ Notes:
                        [(predicate-implies-not? val-type (rtd->record-predicate rtd #t))
                         (cond
                           [(fx= level 3)
-                           (values (make-seq ctxt (make-seq 'effect val rtd) false-rec)
-                                   false-rec ntypes #f #f)]
+                           (let ([rtd (if (get-type rtd) ; ensure that rtd is a single valued expression
+                                          rtd
+                                          `(call ,(make-preinfo-call) ,(lookup-primref 3 '$value) ,rtd))])
+                             (values (make-seq ctxt (make-seq 'effect val rtd) false-rec)
+                                     false-rec ntypes #f #f))]
                           [else
                            (values (make-seq ctxt `(call ,preinfo ,pr ,val ,rtd) false-rec)
                                    false-rec ntypes #f #f)])]
@@ -1301,7 +1304,7 @@ Notes:
                  [else
                   (values ir t types #f #f)])]
                [else
-                (values ir t types #f #f)]))])]
+                (values ir (or t 'ptr) types #f #f)]))])] ; In case there is no saved type, use 'ptr to mark it as single valued 
       [(seq ,[e1 'effect types plxc -> e1 ret1 types t-types f-types] ,e2)
        (cond
          [(predicate-implies? ret1 'bottom)


### PR DESCRIPTION
The first commit fix an error in the reduction of `record?` in cptypes, hat was not checking that the `rtd` expression was single valued. For example in

    (record? 7 (values 1 2)) ; ==> (begin 7 (values 1 2) #f)

To check if it single value, it use the type of the `rtd` expression, that has more information.

Long comment:

I was considering to use a simplified version of the `single-valued?` in cp0, but the problem is that it assume that references are single valued. For example in 

    (let ([r (values 1 2)]) (record? 7 r))
    ==alternative-cptypes==> (let ([r (values 1 2)]) (begin 7 r #f))
                             ; because r is a reference so it is "single valued"
    ==cp0==> (begin 7 (values 1 2) #f)
    ==cp0==> #f

I think that this doesn't cause a problem in cp0 because in cp0 when the expression is moved to an ignored position, it is immediately reduced

    (let ([r (values 1 2)]) (#3%map r '()))
    ==cp0==> (let ([r (values 1 2)]) (begin <cp0 r> '()))
    ==cp0==> (let ([r (values 1 2)]) (begin (void) '()))
    ==cp0==> (let ([r (values 1 2)]) '())

So I think it is correct, but it is not as foolproof as I like.

I was thinking about using `single-valued?` to reduce the first expression in `make-seq` in cptypes (and cp0) in caases where there is no information about the subexpressions, but I must take a more carefully look.

---

The second commit allows the `types` to remember the reference that have a `'ptr`, so it distinguish them from the ones with `#f`. This is only a difference because `'ptr` implies that the expression is single valued. This may increase the memory requirement, but I expect that the difference is not too much. Also, I don't expect it to be very useful now, but it may be helpful in the near future. [I have to update a few comments here and there.] 
