### PR TITLE
Some small improvements to cptypes

### DIFF
--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -26,6 +26,23 @@
                      #;[optimize-level (max (optimize-level) 2)])
         (expand/optimize y)))]))
 
+(define-syntax cptypes/once-equivalent-expansion?
+  ; Replace the default value of run-cp0 with a version that calls
+  ; cp0 only once instead of twice.
+  ; This is useful to test some reductions that are shared with cp0
+  ; or that should be executed in a single pass.
+  (syntax-rules ()
+    [(_ x y)
+     (equivalent-expansion?
+      (parameterize ([run-cp0 (lambda (cp0 c) (cp0 c))]
+                     [#%$suppress-primitive-inlining #f]
+                     #;[optimize-level (max (optimize-level) 2)])
+        (expand/optimize x))
+      (parameterize ([run-cp0 (lambda (cp0 c) (#3%$cptypes c))]
+                     [#%$suppress-primitive-inlining #f]
+                     #;[optimize-level (max (optimize-level) 2)])
+        (expand/optimize y)))]))
+
 (define-syntax cptypes/nocp0-equivalent-expansion?
   ; When run-cp0 is call, use #3%$cptypes insted of the cp0 function provided.
   ; This disables the reductions in cp0.ss, so it's posible to see
@@ -245,8 +262,8 @@
     '(lambda (x y) (if (if (vector? x) (vector? y) #t) (void) (vector? x)))
     '(lambda (x y) (if (if (vector? x) (vector? y) #t) (void) #t)))
   (cptypes-equivalent-expansion?
-    '(lambda (t) (let ([x (if t (begin (newline) #f) #f)]) (number? x)))
-    '(lambda (t) (let ([x (if t (begin (newline) #f) #f)]) #f)))
+    '(lambda (t) (let ([x (if t (begin (newline) #f) #f)]) (display x) (number? x)))
+    '(lambda (t) (let ([x (if t (begin (newline) #f) #f)]) (display x) #f)))
   (cptypes-equivalent-expansion?
     '(lambda (t) (let ([x (if t 1 2)]) (fixnum? x)))
     '(lambda (t) (let ([x (if t 1 2)]) #t)))
@@ -1074,4 +1091,19 @@
     '(begin (optimize-level 0) #f))
   (parameterize ([optimize-level 0])
     (eq? (optimize-level 0) (void)))
+)
+
+(mat cptypes-drop
+  (cptypes/once-equivalent-expansion?
+    '(pair? (list 1 (display 2) 3))
+    '(begin (display 2) #t))
+  (cptypes/once-equivalent-expansion?
+    '(vector? (list 1 (display 2) 3))
+    '(begin (display 2) #f))
+  (cptypes/once-equivalent-expansion?
+    '(pair? (list 1 (vector 2 (display 3) 4)))
+    '(begin (display 3) #t))
+  (cptypes/once-equivalent-expansion?
+    '(vector? (list 1 (vector 2 (display 3) 4)))
+    '(begin (display 3) #f))
 )

--- a/s/primdata.ss
+++ b/s/primdata.ss
@@ -238,7 +238,7 @@
   (tan [sig [(number) -> (number)]] [flags arith-op mifoldable discard ieee r5rs])
   (asin [sig [(number) -> (number)]] [flags arith-op mifoldable discard ieee r5rs])
   (acos [sig [(number) -> (number)]] [flags arith-op mifoldable discard ieee r5rs])
-  (atan [sig [(number) (real real) -> (number)]] [flags arith-op mifoldable discard ieee r5rs])
+  (atan [sig [(number) (real real) -> (number)]] [flags arith-op mifoldable discard cptypes2 ieee r5rs])
   (sqrt [sig [(number) -> (number)]] [flags arith-op mifoldable discard ieee r5rs])
   (exact-integer-sqrt [sig [(exact-integer) -> (exact-integer exact-integer)]] [flags discard discard]) ; could be mifoldable if multiple values were handled
   (expt [sig [(number number) -> (number)]] [flags pure discard true cp02 ieee r5rs]) ; can take too long to fold
@@ -1215,7 +1215,7 @@
   (char-ci=? [sig [(char char ...) -> (boolean)]] [flags pure mifoldable discard cp03 safeongoodargs])   ; not restricted to 2+ arguments
   (char-ci>=? [sig [(char char ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])  ; not restricted to 2+ arguments
   (char-ci>? [sig [(char char ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])   ; not restricted to 2+ arguments
-  (char-name [sig [(sub-ptr) (sub-symbol maybe-char) -> (ptr)]] [flags])
+  (char-name [sig [(sub-ptr) (sub-symbol maybe-char) -> (ptr)]] [flags cptypes2])
   (char-ready? [sig [() (textual-input-port) -> (boolean)]] [flags ieee r5rs])
   (chmod [sig [(pathname sub-ufixnum) -> (void)]] [flags])
   (clear-input-port [sig [() (input-port) -> (void)]] [flags true])


### PR DESCRIPTION
* Remove discardable operations in arguments that are ignored after a reduction

After a reduction like `(pair? (list <x> <y>))` => `(begin (list <x> <y>) #t)` make a semi-shallow
reduction of the argument, so it is further reduced to `(begin <x> <y> #t)` and even remove `<x>` or `<y>` if they have no side effects.

* Add handlers for `atan` and `char-name`

They had a very strange signature, than needs a special case. So I did't include them in the last big update. Anyway, `char-name` needs some special types like `maybe-symbol` that are not currently understand by cptypes, so they are replaced by `ptr` or some more general type. It must be refined later.

* Add fuel for `simple?` and `single-valued?`

Add some recursion with fuel, so `simple?` can detect the expansion of `not`, i.e. `(not x)` => `(if x #f #t)` and other easy cases. It detects only the low hanging cases, and it is not as complete as the versions in cp0.