### PR TITLE
Cptypes: fix reduction of $value in ignored expressions

### DIFF
--- a/mats/cptypes.ms
+++ b/mats/cptypes.ms
@@ -1106,4 +1106,9 @@
   (cptypes/once-equivalent-expansion?
     '(vector? (list 1 (vector 2 (display 3) 4)))
     '(begin (display 3) #f))
+  ; regression test: check that the compiler doesn't loop forever
+  ; when the return arity is unknown
+  (cptypes-equivalent-expansion?
+    '(lambda (f) (box? (box (f))))
+    '(lambda (f) (#3%$value (f)) #t))
 )

--- a/s/cptypes.ss
+++ b/s/cptypes.ss
@@ -173,6 +173,12 @@ Notes:
               `(if ,e1 ,e2 ,e3)])]
           [(case-lambda ,preinfo ,cl* ...)
            void-rec]
+          [(call ,preinfo ,pr ,e)
+           (guard (eq? (primref-name pr) '$value))
+           (cond
+             [(single-valued? e)
+              (make-seq 'effect e void-rec)]
+             [else ir])]
           [(call ,preinfo ,pr ,e* ...)
            (let ([flags (primref-flags pr)])
              (cond


### PR DESCRIPTION
Add a special case in `drop`, so the reduction of `(#3%$values (not-clear-result-arity))` doesn't loop forever.

More details and examples in https://github.com/racket/racket/issues/3088

@mflatt and @samth : Can you give this a try?