### PR TITLE
Call recursive make through $(MAKE)

### DIFF
--- a/makefiles/Mf-boot.in
+++ b/makefiles/Mf-boot.in
@@ -19,7 +19,7 @@ doit: $(bootfiles)
 
 %.boot:
 	( cd .. ; ./workarea $* xc-$* )
-	( cd ../xc-$*/s ; make -f Mf-cross base=../../$(workarea) m=$(m) xm=$* )
+	( cd ../xc-$*/s ; $(MAKE) -f Mf-cross base=../../$(workarea) m=$(m) xm=$* )
 	mkdir -p ../boot/$*
 	for x in `echo scheme.boot petite.boot scheme.h equates.h gc-oce.inc gc-ocd.inc vfasl.inc` ; do\
           if [ ! -h ../xc-$*/boot/$*/$$x ] ; then \


### PR DESCRIPTION
This fixes the build under FreeBSD 12.1 where the system `make` is not compatible with the Chez makefiles and gmake is needed instead.